### PR TITLE
Add average yearly switcher

### DIFF
--- a/src/scripts/SandboxControls.js
+++ b/src/scripts/SandboxControls.js
@@ -6,6 +6,7 @@ import Box from '@material-ui/core/Box';
 import InsertChartOutlinedIcon from '@material-ui/icons/InsertChartOutlined';
 import Button from '@material-ui/core/Button';
 import SaveAltIcon from '@material-ui/icons/SaveAlt';
+import SwapHorizontalCircleIcon from '@material-ui/icons/SwapHorizontalCircle';
 import MailOutlineIcon from '@material-ui/icons/MailOutline';
 import Collapse from '@material-ui/core/Collapse';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
@@ -199,6 +200,9 @@ export default function SandboxControls() {
   // check url parameters for a period variable if none make it blank
   const URLPeriod = urlParams.get('period') ? urlParams.get('period') : '1900-current';
 
+  // check url parameters for a using average bar true (averages are bar) if blank
+  const URLUseAvgBar = urlParams.get('uab') === null ? true : (urlParams.get('uab') === 'true')
+
   // set defaults for intial states of ui compnents
   let URLClimatevariableDisabled = true;
   let URLLocationDisabled = true;
@@ -238,13 +242,18 @@ export default function SandboxControls() {
   // set React state via React Hooks
   const classes = useStyles();
   const [atStart, setAtStart] = useState(true);
-  const [open, setOpen] = React.useState(true);
-  const [chartErrorMessage, setChartErrorMessage] = React.useState('Chart Error');
+  const [open, setOpen] = useState(false);
+  const [chartErrorMessage, setChartErrorMessage] = useState('Chart Error');
 
   const [region, setRegion] = useState(URLRegion);
   const [location, setLocation] = useState(URLLocation);
   const [climatevariable, setClimatevariable] = useState(URLClimatevariable);
   const [period, setPeriod] = useState(URLPeriod);
+
+  // average bars or line
+  // when true average is the bars when false average is line
+  // when true yearly is the line when false yearly is bars
+  const [useAvgBar, setUseAvgBar] = useState(URLUseAvgBar);
 
   const [chartData, setChartData] = useState([{}]);
   const layoutDefaults = { yaxis: { rangemode: 'tozero', title: 'Days' }, xaxis: { rangemode: 'tozero' } };
@@ -281,6 +290,7 @@ export default function SandboxControls() {
     const { chartDataLocation } = props;
     const { chartDataClimatevariable } = props;
     const { chartDataPeriod } = props;
+    const { chartUseAvgBar } = props;
 
     // create new URL parameter object
     const searchParams = new URLSearchParams();
@@ -290,6 +300,7 @@ export default function SandboxControls() {
     searchParams.set('location', chartDataLocation);
     searchParams.set('climatevariable', chartDataClimatevariable);
     searchParams.set('period', chartDataPeriod);
+    searchParams.set('uab', chartUseAvgBar);
 
     // convert url parameters to a string and add the leading ? so it we can add it
     // to browser history (back button works)
@@ -344,6 +355,7 @@ export default function SandboxControls() {
     const { chartDataClimatevariable } = props;
     const { chartDataPeriod } = props;
     const { climateDataFilesJSONFile } = props;
+    const { chartUseAvgBar } = props;
 
     // update url history this is the point at which we will need to make sure
     // the graph looks the same when shared via url
@@ -351,7 +363,8 @@ export default function SandboxControls() {
       chartDataRegion,
       chartDataLocation,
       chartDataClimatevariable,
-      chartDataPeriod
+      chartDataPeriod,
+      chartUseAvgBar
     });
 
     // limit the possible data file to period
@@ -408,7 +421,8 @@ export default function SandboxControls() {
           chartTitle,
           legnedText: chartType,
           chartType,
-          climatevariable: humandReadablechartDataClimatevariable
+          climatevariable: humandReadablechartDataClimatevariable,
+          chartUseAvgBar,
         };
 
         // if no data will returned than do not proceed to plotly
@@ -422,6 +436,7 @@ export default function SandboxControls() {
 
         // check if region or location has data if not display
         // no data available for location and clear the chart
+        //  TODO needs check for you need more data....
         if (!plotData.hasData()) {
           setOpen(true);
           setChartErrorMessage(`Unfortunately, there is no data available for ${humandReadablechartDataClimatevariable}
@@ -497,7 +512,8 @@ export default function SandboxControls() {
             chartDataLocation: location,
             chartDataClimatevariable: climatevariable,
             chartDataPeriod: period,
-            climateDataFilesJSONFile: responseData
+            climateDataFilesJSONFile: responseData,
+            chartUseAvgBar: useAvgBar
           });
         }
 
@@ -524,7 +540,7 @@ export default function SandboxControls() {
     // when the site fist starts and intializes
     loadData(region, period, atStart);
 
-    // make suire the start state is no false and this will never run again
+    // make sure the start state is no false and this will never run again
     // the loadData function will only update chartdata the first timei t runs
     setAtStart(false);
   }, [atStart]);
@@ -590,7 +606,8 @@ export default function SandboxControls() {
       chartDataLocation: location,
       chartDataClimatevariable: climatevariable,
       chartDataPeriod: period,
-      climateDataFilesJSONFile: climateDataFilesJSON
+      climateDataFilesJSONFile: climateDataFilesJSON,
+      chartUseAvgBar: useAvgBar
     });
   };
 
@@ -602,7 +619,8 @@ export default function SandboxControls() {
       chartDataLocation: newValue,
       chartDataClimatevariable: climatevariable,
       chartDataPeriod: period,
-      climateDataFilesJSONFile: climateDataFilesJSON
+      climateDataFilesJSONFile: climateDataFilesJSON,
+      chartUseAvgBar: useAvgBar
     });
   };
 
@@ -614,7 +632,8 @@ export default function SandboxControls() {
       chartDataLocation: location,
       chartDataClimatevariable: newValue,
       chartDataPeriod: period,
-      climateDataFilesJSONFile: climateDataFilesJSON
+      climateDataFilesJSONFile: climateDataFilesJSON,
+      chartUseAvgBar: useAvgBar
     });
     return null;
   };
@@ -627,7 +646,26 @@ export default function SandboxControls() {
       chartDataLocation: location,
       chartDataClimatevariable: climatevariable,
       chartDataPeriod: newValue,
-      climateDataFilesJSONFile: climateDataFilesJSON
+      climateDataFilesJSONFile: climateDataFilesJSON,
+      chartUseAvgBar: useAvgBar
+    });
+    return null;
+  };
+
+  // handles switching of yearly and average in chart
+  // avg as bars and yearly as line - default
+  // yearly as bars and avg as line
+  const handleSwtichAverageAndYearly= () => {
+    // do something
+    const bool = !useAvgBar;
+    setUseAvgBar(bool);
+    getChartData({
+      chartDataRegion: region,
+      chartDataLocation: location,
+      chartDataClimatevariable: climatevariable,
+      chartDataPeriod: period,
+      climateDataFilesJSONFile: climateDataFilesJSON,
+      chartUseAvgBar: bool
     });
     return null;
   };
@@ -894,6 +932,9 @@ export default function SandboxControls() {
             <Grid item xs={12} className={classes.sandboxExports} >
               <Box className={classes.sandboxExportsButtonBox} fontWeight='fontWeightBold' mt={1} display='flex' flexDirection='row' flexWrap='nowrap' >
                 <div className={classes.fabroot}>
+                  <Button onClick={handleSwtichAverageAndYearly} className={classes.fabsvg} variant="contained" color="default" startIcon={<SwapHorizontalCircleIcon />}>
+                    Switch avg and yrly
+                  </Button>
                   <Button onClick={handleDownloadChartAsPNG} className={classes.fabsvg} variant="contained" color="default" startIcon={<SaveAltIcon />}>
                     .PNG
                   </Button>

--- a/src/scripts/SandboxControls.js
+++ b/src/scripts/SandboxControls.js
@@ -201,7 +201,7 @@ export default function SandboxControls() {
   const URLPeriod = urlParams.get('period') ? urlParams.get('period') : '1900-current';
 
   // check url parameters for a using average bar true (averages are bar) if blank
-  const URLUseAvgBar = urlParams.get('uab') === null ? true : (urlParams.get('uab') === 'true')
+  const URLUseAvgBar = urlParams.get('uab') === null ? true : (urlParams.get('uab') === 'true');
 
   // set defaults for intial states of ui compnents
   let URLClimatevariableDisabled = true;
@@ -422,7 +422,7 @@ export default function SandboxControls() {
           legnedText: chartType,
           chartType,
           climatevariable: humandReadablechartDataClimatevariable,
-          chartUseAvgBar,
+          chartUseAvgBar
         };
 
         // if no data will returned than do not proceed to plotly
@@ -655,7 +655,7 @@ export default function SandboxControls() {
   // handles switching of yearly and average in chart
   // avg as bars and yearly as line - default
   // yearly as bars and avg as line
-  const handleSwtichAverageAndYearly= () => {
+  const handleSwtichAverageAndYearly = () => {
     // do something
     const bool = !useAvgBar;
     setUseAvgBar(bool);
@@ -982,5 +982,6 @@ SandboxControls.propTypes = {
   chartDataLocation: PropTypes.string,
   chartDataClimatevariable: PropTypes.string,
   chartDataPeriod: PropTypes.string,
-  climateDataFilesJSONFile: PropTypes.object
+  climateDataFilesJSONFile: PropTypes.object,
+  chartUseAvgBar: PropTypes.string
 };

--- a/src/scripts/SandboxControls.js
+++ b/src/scripts/SandboxControls.js
@@ -933,7 +933,7 @@ export default function SandboxControls() {
               <Box className={classes.sandboxExportsButtonBox} fontWeight='fontWeightBold' mt={1} display='flex' flexDirection='row' flexWrap='nowrap' >
                 <div className={classes.fabroot}>
                   <Button onClick={handleSwtichAverageAndYearly} className={classes.fabsvg} variant="contained" color="default" startIcon={<SwapHorizontalCircleIcon />}>
-                    Switch avg and yrly
+                    Switch average and yearly
                   </Button>
                   <Button onClick={handleDownloadChartAsPNG} className={classes.fabsvg} variant="contained" color="default" startIcon={<SaveAltIcon />}>
                     .PNG

--- a/src/scripts/SandboxGeneratePlotData.js
+++ b/src/scripts/SandboxGeneratePlotData.js
@@ -1,3 +1,9 @@
+//  TODO
+//    hover labels with good text and values
+//    moving average vs period average
+//    add json config for limits of data/variable combos
+//    better file names
+//    when switching areas we probably need to zero out chart...
 class SandboxGeneratePlotData {
   constructor(props) {
     // style guide driven colors, fonts, ticks may need expanding
@@ -11,6 +17,8 @@ class SandboxGeneratePlotData {
     this.precipitationColor = '#5AB4AC';
     this.temperatureColor = '#FEB24C';
     this.bargap = 0.15;
+    this.legendBarLineX = 0.85;
+    this.legendBarLineY = 1.125;
     this.font = 'Arial';
     this.zeroLineColor = '#000000';
     this.zerolinewidth = '1.25';
@@ -53,7 +61,6 @@ class SandboxGeneratePlotData {
     const min = this.minVal < 0 ? 0 : this.minVal;
     this.prettyRange = SandboxGeneratePlotData.pretty([min, this.maxVal]);
     this.yRange = [this.prettyRange[0], this.prettyRange[this.prettyRange.length - 1]];
-    console.log('this.yValsMovingAverage, this.xValsMovingAverage', this.yValsMovingAverage, this.xValsMovingAverage)
   }
 
   // some regions-locations have no data or -9999 need
@@ -128,7 +135,7 @@ class SandboxGeneratePlotData {
   computeMovingAverage() {
     const data = this.yvals;
     const period = this.periodGroups;
-    const getAverage = (data) => data.reduce((a, b) => a + b, 0) / data.length;
+    const getAverage = (avgArr) => avgArr.reduce((a, b) => a + b, 0) / avgArr.length;
     const movingAverages = [];
 
     // if the period is greater than the length of the dataset
@@ -137,7 +144,7 @@ class SandboxGeneratePlotData {
       return getAverage(data);
     }
     for (let x = 0; x + period - 1 < data.length; x += 1) {
-      movingAverages.push(getAverage(data.slice(x, x + period)))
+      movingAverages.push(getAverage(data.slice(x, x + period)));
     }
     return movingAverages;
   }
@@ -148,16 +155,12 @@ class SandboxGeneratePlotData {
     const period = this.periodGroups;
     const movingAveragesX = [];
 
-    // if the period is greater than the length of the dataset
-    // then return the average of the whole dataset
-    if (period > data.length) {
-      return getAverage(data);
-    }
-    for (let x = 0; x - period - 1  < data.length; x += 1) {
-      movingAveragesX.push(data[x])
+    for (let x = 0; x - period - 1 < data.length; x += 1) {
+      movingAveragesX.push(data[x]);
     }
     return movingAveragesX;
   }
+
   // creates the y values for each period
   xValsPeriodLabel() {
     let count = 0;
@@ -337,10 +340,10 @@ class SandboxGeneratePlotData {
   getLayout() {
     // layout when average is the bar and yearly the line chart
     if (this.useAvgBar) {
-      return this.layoutAverageBar()
+      return this.layoutAverageBar();
     }
     // layout when average is the line and yearly the bar
-    return this.layoutYearBar()
+    return this.layoutYearBar();
   }
 
   static uuidv() {
@@ -356,7 +359,7 @@ class SandboxGeneratePlotData {
     return {
       uid: SandboxGeneratePlotData.uuidv(),
       mode: 'lines',
-      name: 'Average Days',
+      name: 'Average days per year',
       type: 'histogram',
       histfunc: 'avg',
       xbins: {
@@ -388,7 +391,7 @@ class SandboxGeneratePlotData {
     return {
       uid: SandboxGeneratePlotData.uuidv(),
       mode: 'lines',
-      name: 'Annual Days',
+      name: 'Days per year',
       type: 'scatter',
       x: this.xvals,
       y: this.getYvalues(),
@@ -400,7 +403,7 @@ class SandboxGeneratePlotData {
         width: this.AverageWidth,
         dash: 'solid',
         shape: 'linear',
-        simplify:	true
+        simplify: true
       },
       hoverinfo: 'x+y'
       // hovertemplate: ' <br /> %{y:0.2f} Annual ' +
@@ -413,7 +416,7 @@ class SandboxGeneratePlotData {
     return {
       uid: SandboxGeneratePlotData.uuidv(),
       mode: 'lines',
-      name: 'Yearly Days',
+      name: 'Days per year',
       type: 'bar',
       x: this.xvals,
       y: this.getYvalues(),
@@ -432,14 +435,14 @@ class SandboxGeneratePlotData {
       histfunc: 'sum',
       hoverinfo: 'x+y',
       legendgroup: 1,
-      orientation: 'v',
+      orientation: 'v'
       // hovertemplate: 'Average days: %{y:0.2f} for the years %{x}<br><extra></extra>',
-    }
+    };
   }
 
   // trace for averages when year is a bar
   traceMovingAverageLineBase() {
-    return  {
+    return {
       uid: SandboxGeneratePlotData.uuidv(),
       mode: 'lines',
       name: 'Moving Average Days',
@@ -451,18 +454,19 @@ class SandboxGeneratePlotData {
         width: this.AverageWidth,
         dash: 'solid',
         shape: 'spline',
-        simplify:	true
+        simplify: true
       },
       hoverinfo: 'x+y',
       visible: 'legendonly'
-    }
+    };
   }
+
   // trace for averages when year is a bar
   traceAverageLine() {
-    return  {
+    return {
       uid: SandboxGeneratePlotData.uuidv(),
       mode: 'lines',
-      name: 'Average Days',
+      name: 'Average days per year',
       type: 'scatter',
       x: this.xValsPeriod,
       y: this.yValsAvgByPeriod,
@@ -471,11 +475,10 @@ class SandboxGeneratePlotData {
         width: this.AverageWidth,
         dash: 'solid',
         shape: 'spline',
-        simplify:	true
-
+        simplify: true
       },
       hoverinfo: 'x+y'
-    }
+    };
   }
 
   // layout  when average is a bar
@@ -491,8 +494,8 @@ class SandboxGeneratePlotData {
         yanchor: 'top',
         autosize: true,
         orientation: 'h',
-        x: .85,
-        y: 1.1,
+        x: this.legendBarLineX,
+        y: this.legendBarLineY,
         font: {
           family: this.font,
           size: this.fontSizeLabels
@@ -537,7 +540,7 @@ class SandboxGeneratePlotData {
           size: this.fontSizeLabelsSecondary
         },
         title: {
-          text: `${this.periodGroups}-Year Average`,
+          text: `${this.periodGroups}-Year Averages`,
           font: {
             family: this.font,
             size: this.fontSizeLabels
@@ -665,8 +668,8 @@ class SandboxGeneratePlotData {
         yanchor: 'top',
         autosize: true,
         orientation: 'h',
-        x: .85,
-        y: 1.1,
+        x: this.legendBarLineX,
+        y: this.legendBarLineY,
         font: {
           family: this.font,
           size: this.fontSizeLabels
@@ -711,7 +714,7 @@ class SandboxGeneratePlotData {
           size: this.fontSizeLabelsSecondary
         },
         title: {
-          text: `${this.periodGroups}-Year Average`,
+          text: 'Year',
           font: {
             family: this.font,
             size: this.fontSizeLabels

--- a/src/scripts/SandboxGeneratePlotData.js
+++ b/src/scripts/SandboxGeneratePlotData.js
@@ -17,8 +17,11 @@ class SandboxGeneratePlotData {
     this.gridColor = '#BFBFBF';
     this.AverageAllFontColor = '#000000';
     this.AverageAllColor = '#858585';
+    this.AverageMovingColor = '#858585';
     this.AverageAllWidth = '6';
     this.AverageAllFontSize = '14pt';
+    this.AverageWidth = '3';
+    this.AverageColor = '#000000';
     this.gridWidth = '1';
     this.fontSizePrimary = '14pt';
     this.fontSizeLabels = '12pt';
@@ -27,6 +30,7 @@ class SandboxGeneratePlotData {
     this.xmax = props.xmax;
     this.xvals = props.xvals;
     this.yvals = props.yvals;
+    this.useAvgBar = props.chartUseAvgBar;
     this.maxVal = Math.max(...this.yvals);
     this.minVal = Math.min(...this.yvals);
     this.chartTitle = props.chartTitle;
@@ -38,6 +42,8 @@ class SandboxGeneratePlotData {
     this.textAngle = 90;
     this.yValsSumByPeriod = this.yValsSumByPeriod();
     this.yValsAvgByPeriod = this.yValsAvgByPeriod();
+    this.yValsMovingAverage = this.computeMovingAverage();
+    this.xValsMovingAverage = this.movingAverageXValues();
     this.xValsPeriod = this.xValsPeriod();
     this.xValsPeriodLabel = this.xValsPeriodLabel();
     const sumAll = this.yValsSumAll();
@@ -47,6 +53,7 @@ class SandboxGeneratePlotData {
     const min = this.minVal < 0 ? 0 : this.minVal;
     this.prettyRange = SandboxGeneratePlotData.pretty([min, this.maxVal]);
     this.yRange = [this.prettyRange[0], this.prettyRange[this.prettyRange.length - 1]];
+    console.log('this.yValsMovingAverage, this.xValsMovingAverage', this.yValsMovingAverage, this.xValsMovingAverage)
   }
 
   // some regions-locations have no data or -9999 need
@@ -117,6 +124,40 @@ class SandboxGeneratePlotData {
     return ticks;
   }
 
+  // calc moving average
+  computeMovingAverage() {
+    const data = this.yvals;
+    const period = this.periodGroups;
+    const getAverage = (data) => data.reduce((a, b) => a + b, 0) / data.length;
+    const movingAverages = [];
+
+    // if the period is greater than the length of the dataset
+    // then return the average of the whole dataset
+    if (period > data.length) {
+      return getAverage(data);
+    }
+    for (let x = 0; x + period - 1 < data.length; x += 1) {
+      movingAverages.push(getAverage(data.slice(x, x + period)))
+    }
+    return movingAverages;
+  }
+
+  // calc moving average
+  movingAverageXValues() {
+    const data = this.xvals;
+    const period = this.periodGroups;
+    const movingAveragesX = [];
+
+    // if the period is greater than the length of the dataset
+    // then return the average of the whole dataset
+    if (period > data.length) {
+      return getAverage(data);
+    }
+    for (let x = this.periodGroups; x - period - 1  < data.length; x += 1) {
+      movingAveragesX.push(data[x])
+    }
+    return movingAveragesX;
+  }
   // creates the y values for each period
   xValsPeriodLabel() {
     let count = 0;
@@ -154,7 +195,6 @@ class SandboxGeneratePlotData {
         return value <= -50 ? undefined : value;
       }
       count += 1;
-      return value <= -50 ? undefined : value;
     });
     return yValsPeriodAll.filter((value) => value !== undefined);
   }
@@ -282,7 +322,25 @@ class SandboxGeneratePlotData {
       this.yValsAvgAll = 0;
     }
     if (this.maxVal === -Infinity) return [{}];
-    return [this.getTrace1(), this.getTrace2()];
+
+    // is average is the bar and yearly the line chart
+    if (this.useAvgBar) {
+      return [this.traceAverageBar(), this.traceYearlyLine()];
+    }
+
+    // is average is the line and yearly the bar
+    // return [this.traceYearlyBar(), this.traceAverageLine()];
+    return [this.traceYearlyBar(), this.traceAverageLine(), this.traceMovingAverageLineBase()];
+  }
+
+  // get the chart layout
+  getLayout() {
+    // layout when average is the bar and yearly the line chart
+    if (this.useAvgBar) {
+      return this.layoutAverageBar()
+    }
+    // layout when average is the line and yearly the bar
+    return this.layoutYearBar()
   }
 
   static uuidv() {
@@ -293,7 +351,8 @@ class SandboxGeneratePlotData {
     });
   }
 
-  getTrace1() {
+  // trace for averages when average is a bar
+  traceAverageBar() {
     return {
       uid: SandboxGeneratePlotData.uuidv(),
       mode: 'lines',
@@ -324,7 +383,8 @@ class SandboxGeneratePlotData {
     };
   }
 
-  getTrace2() {
+  // trace for year when average is a bar
+  traceYearlyLine() {
     return {
       uid: SandboxGeneratePlotData.uuidv(),
       mode: 'lines',
@@ -341,7 +401,78 @@ class SandboxGeneratePlotData {
     };
   }
 
-  getLayout() {
+  // trace for year when year is a bar
+  traceYearlyBar() {
+    return {
+      uid: SandboxGeneratePlotData.uuidv(),
+      mode: 'lines',
+      name: 'Yearly Days',
+      type: 'bar',
+      x: this.xvals,
+      y: this.getYvalues(),
+      xbins: {
+        start: this.xmin,
+        end: this.xmax,
+        size: 5
+      },
+      marker: {
+        line: {
+          color: this.barColor,
+          width: 1
+        },
+        color: this.barColor
+      },
+      histfunc: 'sum',
+      hoverinfo: 'x+y',
+      legendgroup: 1,
+      orientation: 'v',
+      // hovertemplate: 'Average days: %{y:0.2f} for the years %{x}<br><extra></extra>',
+    }
+  }
+
+  // trace for averages when year is a bar
+  traceMovingAverageLineBase() {
+    return  {
+      uid: SandboxGeneratePlotData.uuidv(),
+      mode: 'lines',
+      name: 'Moving Average Days',
+      type: 'scatter',
+      x: this.xValsMovingAverage,
+      y: this.yValsMovingAverage,
+      line: {
+        color: this.AverageColor,
+        width: this.AverageWidth,
+        dash: 'solid',
+        shape: 'linear',
+        simplify:	true
+      },
+      hoverinfo: 'x+y',
+      visible: 'legendonly'
+    }
+  }
+  // trace for averages when year is a bar
+  traceAverageLine() {
+    return  {
+      uid: SandboxGeneratePlotData.uuidv(),
+      mode: 'lines',
+      name: 'Average Days',
+      type: 'scatter',
+      x: this.xValsPeriod,
+      y: this.yValsAvgByPeriod,
+      line: {
+        color: this.AverageColor,
+        width: this.AverageWidth,
+        dash: 'solid',
+        shape: 'linear',
+        simplify:	true
+
+      },
+      hoverinfo: 'x+y'
+    }
+  }
+
+  // layout  when average is a bar
+  layoutAverageBar() {
     return {
       displayModeBar: false,
       autosize: true,
@@ -350,11 +481,11 @@ class SandboxGeneratePlotData {
       plot_bgcolor: this.chartBackgroundColor,
       paper_bgcolor: this.chartBackgroundColor,
       legend: {
+        yanchor: 'top',
         autosize: true,
         orientation: 'h',
-        xanchor: 'center',
-        x: 0.08,
-        y: 1.125,
+        x: .85,
+        y: 1.1,
         font: {
           family: this.font,
           size: this.fontSizeLabels
@@ -406,7 +537,180 @@ class SandboxGeneratePlotData {
           }
         },
         constraintoward: 'center',
+        spikethickness: 4,
+        displayModeBar: false,
+        autosize: true
+      },
+      yaxis: {
+        title: {
+          text: 'Days',
+          font: {
+            family: this.font,
+            size: this.fontSizeLabels
+          }
+        },
+        rangemode: 'tozero',
+        range: this.yRange,
+        type: 'linear',
+        ticks: 'outside',
+        tickcolor: this.zeroLineColor,
+        tickwidth: this.zerolinewidth,
+        autorange: false,
+        showspikes: false,
+        fixedrange: true,
+        showline: true,
+        linecolor: this.zeroLineColor,
+        linewidth: this.zerolinewidth,
+        zerolinecolor: this.zeroLineColor,
+        zerolinewidth: this.zerolinewidth,
+        gridcolor: this.gridColor,
+        gridwidth: this.gridwidth,
+        bargap: this.bargap
+      },
+      template: {
+        layout: {
+          hovermode: 'closest',
+          hoverinfo: 'x+y',
+          plot_bgcolor: this.chartBackgroundColor,
+          paper_bgcolor: this.chartBackgroundColor
+        }
+      },
+      annotations: [{
+        xref: 'x',
+        yref: 'y',
+        x: this.xmax + 2.5,
+        y: this.yValsAvgAll.toFixed(1),
+        text: `Average days ${this.yValsAvgAll.toFixed(1)}`,
+        showarrow: true,
+        arrowhead: 7,
+        arrowsize: 2,
+        arrowwidth: 2,
+        arrowcolor: this.AverageAllColor,
+        ay: -100,
+        ax: 10,
+        font: {
+          family: this.font,
+          size: this.AverageAllFontSize,
+          color: this.AverageAllFontColor
+        }
+      }],
+      shapes: [{
+        type: 'line',
+        layer: 'below',
+        x0: this.xmin - 5,
+        y0: this.yValsAvgAll.toFixed(1),
+        x1: this.xmax + 5,
+        y1: this.yValsAvgAll.toFixed(1),
+        line: {
+          color: this.AverageAllColor,
+          width: this.AverageAllWidth
+        }
+      },
+      {
+        type: 'line',
+        layer: 'above',
+        x0: this.xmin - 5,
+        y0: 0,
+        x1: this.xmax + 5,
+        y1: 0,
+        line: {
+          color: this.zeroLineColor,
+          width: this.zerolinewidth
+        }
+      },
+      {
+        type: 'line',
+        layer: 'above',
+        x0: this.xmin - 5,
+        y0: this.yRange[this.yRange.length - 1],
+        x1: this.xmax + 5,
+        y1: this.yRange[this.yRange.length - 1],
+        line: {
+          color: this.gridColor,
+          width: this.gridwidth
+        }
+      },
+      {
+        type: 'line',
+        layer: 'above',
+        x0: this.xmin - 5,
+        y0: this.yRange[0],
+        x1: this.xmax + 5,
+        y1: this.yRange[0],
+        line: {
+          color: this.zeroLineColor,
+          width: this.zerolinewidth
+        }
+      }]
+    };
+  }
 
+  // layout  when year is a bar
+  layoutYearBar() {
+    return {
+      displayModeBar: false,
+      autosize: true,
+      height: 1,
+      bargap: this.bargap,
+      plot_bgcolor: this.chartBackgroundColor,
+      paper_bgcolor: this.chartBackgroundColor,
+      legend: {
+        yanchor: 'top',
+        autosize: true,
+        orientation: 'h',
+        x: .85,
+        y: 1.1,
+        font: {
+          family: this.font,
+          size: this.fontSizeLabels
+        }
+      },
+      title: {
+        text: this.chartTitle,
+        font: {
+          family: this.font,
+          size: this.fontSizePrimary
+        },
+        x: 0.4
+      },
+      xaxis: {
+        type: 'linear',
+        range: [this.xmin - 5, this.xmax + 5],
+        autorange: false,
+        automargin: false,
+        showspikes: false,
+        zeroline: true,
+        showline: false,
+        showgrid: false,
+        fixedrange: true,
+        rangemode: 'tozero',
+        zerolinecolor: this.zeroLineColor,
+        zerolinewidth: this.zerolinewidth,
+
+        dtick: 5,
+        tick0: 0,
+        tickangle: this.textAngle,
+        tickformat: '',
+        tickprefix: '',
+        nticks: this.periodGroups,
+        // tickmode: 'array',
+        // tickvals: this.xValsPeriod,
+        // ticktext: this.xValsPeriodLabel,
+        ticks: 'outside',
+        tickcolor: this.zeroLineColor,
+        tickwidth: this.zerolinewidth,
+        tickfont: {
+          family: this.font,
+          size: this.fontSizeLabelsSecondary
+        },
+        title: {
+          text: `${this.periodGroups}-Year Average`,
+          font: {
+            family: this.font,
+            size: this.fontSizeLabels
+          }
+        },
+        constraintoward: 'center',
         spikethickness: 4,
         displayModeBar: false,
         autosize: true

--- a/src/scripts/SandboxGeneratePlotData.js
+++ b/src/scripts/SandboxGeneratePlotData.js
@@ -153,7 +153,7 @@ class SandboxGeneratePlotData {
     if (period > data.length) {
       return getAverage(data);
     }
-    for (let x = this.periodGroups; x - period - 1  < data.length; x += 1) {
+    for (let x = 0; x - period - 1  < data.length; x += 1) {
       movingAveragesX.push(data[x])
     }
     return movingAveragesX;
@@ -329,8 +329,8 @@ class SandboxGeneratePlotData {
     }
 
     // is average is the line and yearly the bar
-    // return [this.traceYearlyBar(), this.traceAverageLine()];
-    return [this.traceYearlyBar(), this.traceAverageLine(), this.traceMovingAverageLineBase()];
+    return [this.traceYearlyBar(), this.traceAverageLine()];
+    // return [this.traceYearlyBar(), this.traceAverageLine(), this.traceMovingAverageLineBase()];
   }
 
   // get the chart layout

--- a/src/scripts/SandboxGeneratePlotData.js
+++ b/src/scripts/SandboxGeneratePlotData.js
@@ -395,6 +395,13 @@ class SandboxGeneratePlotData {
       marker: {
         color: this.annualLineColor
       },
+      line: {
+        color: this.AverageColor,
+        width: this.AverageWidth,
+        dash: 'solid',
+        shape: 'linear',
+        simplify:	true
+      },
       hoverinfo: 'x+y'
       // hovertemplate: ' <br /> %{y:0.2f} Annual ' +
       // this.climatevariable + ' for the year: %{x}<extra></extra>  <br /> ',
@@ -443,7 +450,7 @@ class SandboxGeneratePlotData {
         color: this.AverageColor,
         width: this.AverageWidth,
         dash: 'solid',
-        shape: 'linear',
+        shape: 'spline',
         simplify:	true
       },
       hoverinfo: 'x+y',
@@ -463,7 +470,7 @@ class SandboxGeneratePlotData {
         color: this.AverageColor,
         width: this.AverageWidth,
         dash: 'solid',
-        shape: 'linear',
+        shape: 'spline',
         simplify:	true
 
       },


### PR DESCRIPTION
Most charts have summed data for the period as the bars and averages as a trend line. The original and still default does the opposite.  This should allow us to take a look at the more typical way of making the average a line against the yearly  data as the chart